### PR TITLE
Add env template and ignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Rename to .env and fill in your credentials
+BUNNY_API_KEY=
+BUNNY_LIBRARY_ID=
+WP_USER=
+WP_APP_PW=
+WP_SITE=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Video Upload Kit
+
+This kit provides a lightweight pipeline for downloading videos, uploading them
+ to Bunny.net Stream and publishing posts on WordPress.
+
+## Setup
+Run `./setup.sh` once to install the required packages (Python modules and
+ffmpeg).
+
+## Workflow
+1. Add your links and titles to `upload.txt` (`url - My Title` per line).
+2. Run `python download_videos.py` to fetch videos and thumbnails.
+3. Run `python upload_bunny.py` to upload them to Bunny Stream.
+4. Run `python wp_publish.py --site https://example.com` to create WordPress posts.
+5. Run `./cleanup.sh` to remove temporary files when finished.
+
+A `.env.example` file is provided as a template. Copy it to `.env` and add your
+keys there. The scripts read these variables:
+- `BUNNY_API_KEY` and `BUNNY_LIBRARY_ID`
+- `WP_USER` and `WP_APP_PW`
+- `WP_SITE` (used by `run_all.sh`)
+
+A convenience script `run_all.sh` executes the three phases in sequence using
+those environment variables.

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+rm -rf downloads bunny_results.json wp_results.json __pycache__
+echo "Cleanup complete"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+yt-dlp
+requests
+tenacity
+tqdm

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+python3 download_videos.py "$@"
+python3 upload_bunny.py
+python3 wp_publish.py --site "$WP_SITE"
+
+echo "All steps completed"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Install system packages
+if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y python3 python3-pip ffmpeg
+fi
+
+# Install Python dependencies
+python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+
+echo "Setup complete"

--- a/wp_publish.py
+++ b/wp_publish.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3
 """
-Phase‑3: WordPress autoposter (credentials baked‑in)
-===================================================
+Phase‑3: WordPress autoposter
+=============================
 
-**Caution ⚠️** – This version contains hard‑coded credentials:
-```
-user      : president
-app pass  : Hfml QHH5 kmZt q2tM bAPH 2TRH
-```
-Keep the file private.
+Publishes Bunny.net embed codes to a WordPress site. Credentials are
+provided via command‑line flags or the ``WP_USER`` and ``WP_APP_PW``
+environment variables.
 
 Pipeline
 --------
@@ -38,9 +35,9 @@ import requests
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 from tqdm import tqdm
 
-# --- baked‑in WP credentials -------------------------------------------------
-DEFAULT_USER = "president"
-DEFAULT_PW = "Hfml QHH5 kmZt q2tM bAPH 2TRH"
+# --- default credentials from environment ------------------------------------
+DEFAULT_USER = os.getenv("WP_USER")
+DEFAULT_PW = os.getenv("WP_APP_PW")
 
 # -----------------------------------------------------------------------------
 
@@ -96,10 +93,13 @@ def main():
     ap.add_argument("--status", default="publish", help="Post status: publish|draft|private")
     ap.add_argument("--width", type=int, default=640, help="Iframe width")
     ap.add_argument("--height", type=int, default=360, help="Iframe height")
-    # allow override of baked‑in creds
-    ap.add_argument("--user", default=os.getenv("WP_USER", DEFAULT_USER))
-    ap.add_argument("--password", default=os.getenv("WP_APP_PW", DEFAULT_PW))
+    # allow override of env credentials
+    ap.add_argument("--user", default=DEFAULT_USER, help="WordPress username [env WP_USER]")
+    ap.add_argument("--password", default=DEFAULT_PW, help="WordPress application password [env WP_APP_PW]")
     args = ap.parse_args()
+
+    if not args.user or not args.password:
+        sys.exit("WordPress credentials required. Use flags or set WP_USER and WP_APP_PW.")
 
     auth = auth_header(args.user, args.password)
 


### PR DESCRIPTION
## Summary
- add `.env.example` for credentials
- update README to reference the env file
- ignore `.env` and Python caches

## Testing
- `python -m py_compile download_videos.py upload_bunny.py wp_publish.py`


------
https://chatgpt.com/codex/tasks/task_e_6885a7086288832d9d1a5767fbb3423d