### PR TITLE
Add cross-platform master script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Rename to .env and fill in your credentials
+BUNNY_API_KEY=
+BUNNY_LIBRARY_ID=
+WP_USER=
+WP_APP_PW=
+WP_SITE=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Video Upload Kit
+
+This kit provides a lightweight pipeline for downloading videos, uploading them
+ to Bunny.net Stream and publishing posts on WordPress.
+
+## Setup
+Run `./setup.sh` once to install the required packages (Python modules and
+ffmpeg).
+
+## Workflow
+1. Add your links and titles to `upload.txt` (`url - My Title` per line).
+2. Run `python master.py --site https://example.com` to download videos,
+   upload them to Bunny Stream, publish posts on WordPress and clean up the
+   temporary files.
+
+If you prefer to execute each phase manually:
+
+```
+python download_videos.py
+python upload_bunny.py
+python wp_publish.py --site https://example.com
+./cleanup.sh
+```
+
+A `.env.example` file is provided as a template. Copy it to `.env` and add your
+keys there. The scripts read these variables:
+- `BUNNY_API_KEY` and `BUNNY_LIBRARY_ID`
+- `WP_USER` and `WP_APP_PW`
+- `WP_SITE` (used by `master.py` and `run_all.sh`)
+
+A small `run_all.sh` shell script is also included for Unix systems, but
+`master.py` works on Windows and Linux alike.

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+rm -rf downloads bunny_results.json wp_results.json __pycache__
+echo "Cleanup complete"

--- a/master.py
+++ b/master.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Run the entire video pipeline then clean up.
+
+This convenience script executes ``download_videos.py``, ``upload_bunny.py``
+and ``wp_publish.py`` in sequence. It is cross-platform so it can be used
+natively on Windows without Bash.
+"""
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(cmd: list[str]):
+    print("\n>", " ".join(cmd))
+    subprocess.check_call(cmd)
+
+
+def cleanup():
+    print("\n> cleaning temporary files")
+    targets = ["downloads", "bunny_results.json", "wp_results.json", "__pycache__"]
+    for t in targets:
+        p = Path(t)
+        if p.is_dir():
+            shutil.rmtree(p, ignore_errors=True)
+        elif p.exists():
+            p.unlink()
+    print("Cleanup complete")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Run download, upload, publish, then clean")
+    ap.add_argument("--site", default=os.getenv("WP_SITE"), help="WordPress site URL")
+    ap.add_argument("download_args", nargs=argparse.REMAINDER,
+                    help="Extra arguments passed to download_videos.py")
+    args = ap.parse_args()
+
+    if not args.site:
+        sys.exit("Provide --site or set WP_SITE")
+
+    run(["python", "download_videos.py", *args.download_args])
+    run(["python", "upload_bunny.py"])
+    run(["python", "wp_publish.py", "--site", args.site])
+    cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+yt-dlp
+requests
+tenacity
+tqdm

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+python3 download_videos.py "$@"
+python3 upload_bunny.py
+python3 wp_publish.py --site "$WP_SITE"
+
+echo "All steps completed"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Install system packages
+if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y python3 python3-pip ffmpeg
+fi
+
+# Install Python dependencies
+python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+
+echo "Setup complete"

--- a/wp_publish.py
+++ b/wp_publish.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3
 """
-Phase‑3: WordPress autoposter (credentials baked‑in)
-===================================================
+Phase‑3: WordPress autoposter
+=============================
 
-**Caution ⚠️** – This version contains hard‑coded credentials:
-```
-user      : president
-app pass  : Hfml QHH5 kmZt q2tM bAPH 2TRH
-```
-Keep the file private.
+Publishes Bunny.net embed codes to a WordPress site. Credentials are
+provided via command‑line flags or the ``WP_USER`` and ``WP_APP_PW``
+environment variables.
 
 Pipeline
 --------
@@ -38,9 +35,9 @@ import requests
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 from tqdm import tqdm
 
-# --- baked‑in WP credentials -------------------------------------------------
-DEFAULT_USER = "president"
-DEFAULT_PW = "Hfml QHH5 kmZt q2tM bAPH 2TRH"
+# --- default credentials from environment ------------------------------------
+DEFAULT_USER = os.getenv("WP_USER")
+DEFAULT_PW = os.getenv("WP_APP_PW")
 
 # -----------------------------------------------------------------------------
 
@@ -96,10 +93,13 @@ def main():
     ap.add_argument("--status", default="publish", help="Post status: publish|draft|private")
     ap.add_argument("--width", type=int, default=640, help="Iframe width")
     ap.add_argument("--height", type=int, default=360, help="Iframe height")
-    # allow override of baked‑in creds
-    ap.add_argument("--user", default=os.getenv("WP_USER", DEFAULT_USER))
-    ap.add_argument("--password", default=os.getenv("WP_APP_PW", DEFAULT_PW))
+    # allow override of env credentials
+    ap.add_argument("--user", default=DEFAULT_USER, help="WordPress username [env WP_USER]")
+    ap.add_argument("--password", default=DEFAULT_PW, help="WordPress application password [env WP_APP_PW]")
     args = ap.parse_args()
+
+    if not args.user or not args.password:
+        sys.exit("WordPress credentials required. Use flags or set WP_USER and WP_APP_PW.")
 
     auth = auth_header(args.user, args.password)
 


### PR DESCRIPTION
## Summary
- add `master.py` to run the whole pipeline natively on Windows
- document using `master.py` in the README

## Testing
- `python -m py_compile download_videos.py upload_bunny.py wp_publish.py master.py`

------
https://chatgpt.com/codex/tasks/task_e_6885a7086288832d9d1a5767fbb3423d