### PR TITLE
Support env vars from .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ python wp_publish.py --site https://example.com
 ```
 
 A `.env.example` file is provided as a template. Copy it to `.env` and add your
-keys there. The scripts read these variables:
+keys there. The scripts automatically load this file (via `python-dotenv`) and
+read these variables:
 - `BUNNY_API_KEY` and `BUNNY_LIBRARY_ID`
 - `WP_USER` and `WP_APP_PW`
 - `WP_SITE` (used by `master.py` and `run_all.sh`)

--- a/master.py
+++ b/master.py
@@ -12,6 +12,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 
 def run(cmd: list[str]):
     print("\n>", " ".join(cmd))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ yt-dlp
 requests
 tenacity
 tqdm
+python-dotenv

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+if [ -f .env ]; then
+    set -a
+    . .env
+    set +a
+fi
+
 python3 download_videos.py "$@"
 python3 upload_bunny.py
 python3 wp_publish.py --site "$WP_SITE"

--- a/upload_bunny.py
+++ b/upload_bunny.py
@@ -20,6 +20,10 @@ import sys
 from pathlib import Path
 from typing import Dict, List
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 import requests
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_random_exponential
 from tqdm import tqdm

--- a/wp_publish.py
+++ b/wp_publish.py
@@ -31,9 +31,12 @@ import sys
 from pathlib import Path
 from typing import List
 
+from dotenv import load_dotenv
 import requests
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 from tqdm import tqdm
+
+load_dotenv()
 
 # --- default credentials from environment ------------------------------------
 DEFAULT_USER = os.getenv("WP_USER")


### PR DESCRIPTION
## Summary
- load environment variables from a `.env` file in Python scripts
- support `.env` loading in the `run_all.sh` helper
- document `.env` handling in the README
- add `python-dotenv` to requirements

## Testing
- `python -m py_compile master.py upload_bunny.py wp_publish.py download_videos.py`

------
https://chatgpt.com/codex/tasks/task_e_6885b503e3b0832db218f265d4bfd20a