### PR TITLE
Include thumbnail paths in upload summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ python wp_publish.py --site https://example.com
 ./cleanup.sh
 ```
 
+Running `upload_bunny.py` creates `bunny_results.json` containing the embed URL
+for each video and, when available, the local path to the thumbnail image.
+
 A `.env.example` file is provided as a template. Copy it to `.env` and add your
 keys there. The scripts automatically load this file (via `python-dotenv`) and
 read these variables:

--- a/upload_bunny.py
+++ b/upload_bunny.py
@@ -82,8 +82,14 @@ def process(idx: int, mp4: Path, jpg: Path | None, key: str, lib: int, results: 
         upload_binary(key, lib, vid, mp4)
         if jpg and jpg.exists():
             set_thumb(key, lib, vid, jpg)
+            thumb = str(jpg)
+        else:
+            thumb = None
         embed = EMBED_PATTERN.format(lib=lib, vid=vid)
-        results.append({"title": title, "video_id": vid, "embed_url": embed, "status": "ok"})
+        rec = {"title": title, "video_id": vid, "embed_url": embed, "status": "ok"}
+        if thumb:
+            rec["thumbnail"] = thumb
+        results.append(rec)
         print(f"[OK] {idx}: {title} -> {vid}")
     except Exception as e:
         results.append({"title": title, "status": "error", "error": str(e)})

--- a/wp_publish.py
+++ b/wp_publish.py
@@ -119,7 +119,7 @@ def main():
     for rec in tqdm(ok_records, desc="Posting to WP"):
         title = rec["title"]
         embed = rec["embed_url"]
-        thumb_path = Path(rec["thumbnail"]) if rec.get("thumbnail") else None
+        thumb_path = Path(rec["thumbnail"]) if "thumbnail" in rec else None
         try:
             media_id = upload_media(args.site, auth, thumb_path) if thumb_path and thumb_path.exists() else 0
             content = make_iframe(embed, args.width, args.height)


### PR DESCRIPTION
## Summary
- record thumbnail paths in `upload_bunny.py`
- consume the stored path in `wp_publish.py`
- document the new `bunny_results.json` field

## Testing
- `python -m py_compile upload_bunny.py wp_publish.py`

------
https://chatgpt.com/codex/tasks/task_e_6885bc3beacc832da38255dcc70195b6