### PR TITLE
Switch to new Bunny API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ python wp_publish.py --site https://example.com
 ```
 
 Running `upload_bunny.py` creates `bunny_results.json` containing the embed URL
-for each video and, when available, the local path to the thumbnail image.
+for each video and, when available, the local path to the thumbnail image. The
+uploader now defaults to the latest Bunny.net API endpoint at
+`https://api.bunny.net`. You can override this by setting `BUNNY_BASE_URL` in
+your `.env` file if needed.
 
 A `.env.example` file is provided as a template. Copy it to `.env` and add your
 keys there. Each line must be written as `KEY=value` with no extra spaces or
@@ -35,6 +38,7 @@ quotes (for example: `WP_SITE=https://example.com`). The scripts automatically
 load this file (via [`python-dotenv`](https://github.com/theskumar/python-dotenv)) and
 read these variables:
 - `BUNNY_API_KEY` and `BUNNY_LIBRARY_ID`
+- `BUNNY_BASE_URL` (optional API host, defaults to `https://api.bunny.net`)
 - `WP_USER` and `WP_APP_PW`
 - `WP_SITE` (used by `master.py` and `run_all.sh`)
 

--- a/upload_bunny.py
+++ b/upload_bunny.py
@@ -34,7 +34,7 @@ from tqdm import tqdm
 API_KEY_DEFAULT = os.getenv("BUNNY_API_KEY")
 LIB_ID_DEFAULT = os.getenv("BUNNY_LIBRARY_ID")
 
-BASE_URL = "https://video.bunnycdn.com"
+BASE_URL = os.getenv("BUNNY_BASE_URL", "https://api.bunny.net")
 EMBED_PATTERN = "https://iframe.mediadelivery.net/embed/{lib}/{vid}"
 
 # ——————————————————————————— helper functions ——————————————————————————


### PR DESCRIPTION
## Summary
- update Bunny Stream uploader to use `https://api.bunny.net`
- document optional `BUNNY_BASE_URL` in README

## Testing
- `python -m py_compile master.py download_videos.py upload_bunny.py wp_publish.py`

------
https://chatgpt.com/codex/tasks/task_e_6885bd3ba574832d8023f0565b55d3d2