### PR TITLE
Update env example formatting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Rename to .env and fill in your credentials
-BUNNY_API_KEY=
-BUNNY_LIBRARY_ID=
-WP_USER=
-WP_APP_PW=
-WP_SITE=
+BUNNY_API_KEY=your_bunny_api_key_here  # string
+BUNNY_LIBRARY_ID=123456                # integer
+WP_USER=your_wp_username
+WP_APP_PW=abcd efgh ijkl mnop          # application password
+WP_SITE=https://example.com            # full URL

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
+.env.example
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ your `.env` file if needed.
 
 A `.env.example` file is provided as a template. Copy it to `.env` and add your
 keys there. Each line must be written as `KEY=value` with no extra spaces or
-quotes (for example: `WP_SITE=https://example.com`). The scripts automatically
+quotes (for example: `WP_SITE=https://example.com`). This example file
+illustrates the required formats for each variable. The scripts automatically
 load this file (via [`python-dotenv`](https://github.com/theskumar/python-dotenv)) and
 read these variables:
 - `BUNNY_API_KEY` and `BUNNY_LIBRARY_ID`


### PR DESCRIPTION
## Summary
- expand `.env.example` with example formats
- note the example usage in README
- ignore `.env.example` by default

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885c2a8c9a0832d8e0cf08d0bb63a9e