### PR TITLE
Improve .env parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,14 @@ read these variables:
 
 A small `run_all.sh` shell script is also included for Unix systems, but
 `master.py` works on Windows and Linux alike.
+
+### Troubleshooting `.env` files
+
+If your `.env` contains stray spaces or quotes, the scripts will stop with a
+message like:
+
+```
+Failed to parse .env – check for stray spaces or quotes on line X.
+```
+
+Fix the indicated line so each entry follows the `KEY=value` format.

--- a/master.py
+++ b/master.py
@@ -12,9 +12,38 @@ import subprocess
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values, find_dotenv
+import logging
 
-load_dotenv()
+
+def _load_env() -> dict:
+    env_file = find_dotenv(usecwd=True)
+    if not env_file:
+        return {}
+    logger = logging.getLogger("dotenv.main")
+    msgs: list[logging.LogRecord] = []
+
+    class _Handler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            msgs.append(record)
+
+    handler = _Handler()
+    logger.addHandler(handler)
+    try:
+        values = dotenv_values(env_file)
+    except Exception as e:  # pragma: no cover - just in case
+        logger.removeHandler(handler)
+        sys.exit(f"Failed to parse .env – {e}")
+    logger.removeHandler(handler)
+    if msgs or not values:
+        line = msgs[0].args[0] if msgs else "unknown"
+        sys.exit(
+            f"Failed to parse .env – check for stray spaces or quotes on line {line}."
+        )
+    return {k: v for k, v in values.items() if v is not None}
+
+
+ENV = _load_env()
 
 
 def run(cmd: list[str]):
@@ -36,7 +65,7 @@ def cleanup():
 
 def main() -> None:
     ap = argparse.ArgumentParser(description="Run download, upload, publish, then clean")
-    ap.add_argument("--site", default=os.getenv("WP_SITE"), help="WordPress site URL")
+    ap.add_argument("--site", default=os.getenv("WP_SITE") or ENV.get("WP_SITE"), help="WordPress site URL")
     ap.add_argument("download_args", nargs=argparse.REMAINDER,
                     help="Extra arguments passed to download_videos.py")
     args = ap.parse_args()


### PR DESCRIPTION
## Summary
- use `dotenv_values` and custom parser helpers for `.env`
- exit with a helpful message when `.env` parsing fails
- allow environment variables and CLI flags to override `.env`
- document how malformed `.env` files are reported

## Testing
- `python -m py_compile wp_publish.py upload_bunny.py master.py`
- `python -m py_compile download_videos.py`

------
https://chatgpt.com/codex/tasks/task_e_6885c2a2f5dc832da0b245c9aa1d03f9